### PR TITLE
Fix missing title in AppComponent

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,5 @@
 <app-header></app-header>
 <main>
+  <h1>Hello, {{ title }}</h1>
   <router-outlet></router-outlet>
 </main>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,4 +9,6 @@ import { HeaderComponent } from './header/header.component';
   templateUrl: 'app.component.html',
   styleUrl: 'app.component.scss'
 })
-export class AppComponent { }
+export class AppComponent {
+  title = 'tzt';
+}


### PR DESCRIPTION
## Summary
- add a title property to `AppComponent`
- render title in app root template

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a829dcf38832e9dd2f4eb0eb251ed